### PR TITLE
project.xml / .travis.yml : add clang shadow compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -171,6 +171,50 @@ matrix:
         - gcc-4.9
         - g++-4.9
 # Shadow-compilation setups below inspired by https://docs.travis-ci.com/user/languages/cpp/
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
+    os: linux
+    dist: trusty
+    addons:
+      apt:
+        sources:
+        - llvm-toolchain-trusty-5.0
+        - *pkg_src_zeromq_ubuntu14
+        packages:
+        - *pkg_deps_common
+        - clang-5.0
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
+    os: linux
+    dist: trusty
+    addons:
+      apt:
+        sources:
+        - llvm-toolchain-trusty-4.0
+        - *pkg_src_zeromq_ubuntu14
+        packages:
+        - *pkg_deps_common
+        - clang-4.0
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
+    os: linux
+    dist: trusty
+    addons:
+      apt:
+        sources:
+        - llvm-toolchain-trusty-3.9
+        - *pkg_src_zeromq_ubuntu14
+        packages:
+        - *pkg_deps_common
+        - clang-3.9
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
+    os: linux
+    dist: trusty
+    addons:
+      apt:
+        sources:
+        - llvm-toolchain-trusty-3.8
+        - *pkg_src_zeromq_ubuntu14
+        packages:
+        - *pkg_deps_common
+        - clang-3.8
   - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
     os: linux
     dist: trusty
@@ -229,6 +273,10 @@ matrix:
   - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
   - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
   - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
+  - env: BUILD_TYPE=default-Werror MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
 #  - env: BUILD_TYPE=cmake DO_CLANG_FORMAT_CHECK=1 CLANG_FORMAT=clang-format-5.0
   - env: BUILD_TYPE=clang-format-check CLANG_FORMAT=clang-format-5.0
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 /*
-    fty-asset-mapping-rest - Asset Mapping REST API
+    fty-asset-mapping-rest - Asset mapping REST API
 
     Copyright (C) 2018 - 2019 Eaton
 

--- a/project.xml
+++ b/project.xml
@@ -19,6 +19,7 @@
         <option name = "require_gitignore" value = "1" />
         <option name = "dist" value = "trusty" />
         <option name = "shadow_gcc" value = "2" />
+        <option name = "shadow_clang" value = "2" />
     </target>
     <target name = "jenkins" >
         <option name = "agent_label" value = "devel-image &amp;&amp; x86_64" />


### PR DESCRIPTION
This enables shadow compilation with clang as well, to get a sense of our prevaling antipatterns that different newer compilers warn about, and maybe to help PoC solution patterns on a new dynamically evolving component, to spread the goodness into other codebase afterwards.